### PR TITLE
switch to alpha version of recharts

### DIFF
--- a/hatvp_viz/package-lock.json
+++ b/hatvp_viz/package-lock.json
@@ -18,7 +18,7 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
-        "recharts": "^2.12.7",
+        "recharts": "^2.13.0-alpha.4",
         "stream": "^0.0.2",
         "timers": "^0.1.1",
         "timers-browserify": "^2.0.12",
@@ -15864,14 +15864,14 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.12.7",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
-      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
+      "version": "2.13.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.13.0-alpha.4.tgz",
+      "integrity": "sha512-K9naL6F7pEcDYJE6yFQASSCQecSLPP0JagnvQ9hPtA/aHgsxsnIOjouLP5yrFZehxzfCkV5TEORr7/uNtSr7Qw==",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.21",
-        "react-is": "^16.10.2",
+        "react-is": "^18.3.1",
         "react-smooth": "^4.0.0",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
@@ -15894,9 +15894,9 @@
       }
     },
     "node_modules/recharts/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",

--- a/hatvp_viz/package.json
+++ b/hatvp_viz/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
-    "recharts": "^2.12.7",
+    "recharts": "^2.13.0-alpha.4",
     "stream": "^0.0.2",
     "timers": "^0.1.1",
     "timers-browserify": "^2.0.12",


### PR DESCRIPTION
switch to alpha version of recharts to remove console warning about chart axis